### PR TITLE
Arbitrary number of spark conifgs using --conf

### DIFF
--- a/spark_operator_plugin.py
+++ b/spark_operator_plugin.py
@@ -39,9 +39,10 @@ class SparkSubmitOperator(BashOperator):
    :param master: The master value for the cluster.
         (e.g. spark://23.195.26.187:7077 or yarn-client)
    :type master: string
-   :param conf: Arbitrary Spark configuration property in key=value format.
-        For values that contain spaces wrap “key=value” in quotes.
-   :type conf: string
+   :param conf: Dictionary consisting of arbitrary Spark configuration properties.
+        (e.g. {"spark.eventLog.enabled": "false",
+               "spark.executor.extraJavaOptions": "-XX:+PrintGCDetails -XX:+PrintGCTimeStamps"}
+   :type conf: dict
    :param deploy_mode: Whether to deploy your driver on the worker nodes
         (cluster) or locally as an external client (default: client)
    :type deploy_mode: string
@@ -89,7 +90,7 @@ class SparkSubmitOperator(BashOperator):
         self.application_file = application_file
         self.main_class = main_class
         self.master = master
-        self.conf = conf
+        self.conf = conf or {}
         self.deploy_mode = deploy_mode
         self.other_spark_options = other_spark_options
         self.application_args = application_args
@@ -104,8 +105,9 @@ class SparkSubmitOperator(BashOperator):
             self.bash_command += "--master " + self.master + " "
         if self.is_not_null_and_is_not_empty_str(self.deploy_mode):
             self.bash_command += "--deploy-mode " + self.deploy_mode + " "
-        if self.is_not_null_and_is_not_empty_str(self.conf):
-            self.bash_command += "--conf " + self.conf + " "
+        for conf_key, conf_value in self.conf.items():
+            if self.is_not_null_and_is_not_empty_str(conf_key) and self.is_not_null_and_is_not_empty_str(conf_value):                
+                self.bash_command += "--conf " + "'" + conf_key + "=" + conf_value + "'" + " "
         if self.is_not_null_and_is_not_empty_str(self.other_spark_options):
             self.bash_command += self.other_spark_options + " "
 

--- a/spark_operator_plugin.py
+++ b/spark_operator_plugin.py
@@ -74,7 +74,7 @@ class SparkSubmitOperator(BashOperator):
             application_file,
             main_class=None,
             master=None,
-            conf=None,
+            conf={},
             deploy_mode=None,
             other_spark_options=None,
             application_args=None,
@@ -90,7 +90,7 @@ class SparkSubmitOperator(BashOperator):
         self.application_file = application_file
         self.main_class = main_class
         self.master = master
-        self.conf = conf or {}
+        self.conf = conf
         self.deploy_mode = deploy_mode
         self.other_spark_options = other_spark_options
         self.application_args = application_args


### PR DESCRIPTION
Hi Robert,
Thanks a lot for implementing this library
I've noticed that it doesn't support multiple configurations using --conf parameter like in example below:
`spark-submit --conf spark.eventLog.enabled=false --conf "spark.executor.extraJavaOptions=-XX:+PrintGCDetails -XX:+PrintGCTimeStamps"`
Potentially it could be done using 'other_spark_options' parameter but it doesn't seem convenient in particular since there is already 'conf' parameter
So in this PR I changed type of 'conf' parameter to dict to allow users to pass multiple --conf parameters. Hopefully you will find it useful